### PR TITLE
docs: update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 James McKee
+Copyright (c) 2022 Catppuccin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changes the license to be under `Catppuccin`, as specified in the [template](https://github.com/catppuccin/template/blob/4335bca70b2cc4b8bdd1b51164005207f46aeff6/LICENSE#L3).